### PR TITLE
Fix crash when a plain filter coefficient matrix is passed as p

### DIFF
--- a/R/sgolayfilt.R
+++ b/R/sgolayfilt.R
@@ -55,8 +55,11 @@ choose_engine <- function(x, filter_length, orig_engine) {
 sgolayfilt <- function(x, p = 3, n = p + 3 - p %% 2, m = 0, ts = 1, rowwise = FALSE,
                        engine = c("auto", "fft", "filter")) {
   engine <- match.arg(engine)
-  if (inherits(p, "sgolayFilter") || (!is.null(dim(p)) && dim(p) > 1)) {
+  if (inherits(p, "sgolayFilter") || is.matrix(p)) {
     filt <- p
+    if (nrow(filt) %% 2 == 0) {
+      stop("sgolayfilt: the filter coefficient matrix `p` must have an odd number of rows, got ", nrow(filt))
+    }
   } else {
     filt <- sgolay(p, n, m, ts)
   }

--- a/inst/tests/runit.sgolayfilt.R
+++ b/inst/tests/runit.sgolayfilt.R
@@ -30,3 +30,23 @@ test02_sgolayfilt_matrix_rowwisetrue <- function() {
   checkEquals(yref, y_filter, msg = "Check sgolayfilt on a matrix (rowwise=TRUE, filter engine)")
   checkEquals(yref, y_fft, msg = "Check sgolayfilt on a matrix (rowwise=TRUE, fft engine)")
 }
+
+test03_sgolayfilt_plain_matrix_p <- function() {
+  # p can be a plain matrix without the "sgolayFilter" class (e.g. after
+  # unclass()), not only an object returned directly by sgolay()
+  filt_classed <- sgolay::sgolay(p = 2, n = 5)
+  filt <- unclass(filt_classed)
+  x <- runif(500)
+  yref <- signal::sgolayfilt(x, filt_classed)
+  y_filter <- sgolayfilt(x, filt, engine = "filter")
+  y_fft <- sgolayfilt(x, filt, engine = "fft")
+  checkEquals(yref, y_filter, msg = "Check sgolayfilt with a plain matrix p (filter engine)")
+  checkEquals(yref, y_fft, msg = "Check sgolayfilt with a plain matrix p (fft engine)")
+}
+
+test04_sgolayfilt_even_rows_p_errors <- function() {
+  # An even number of rows has no well-defined center row and must be rejected
+  even_filt <- matrix(1, nrow = 4, ncol = 4)
+  x <- runif(50)
+  checkException(sgolayfilt(x, even_filt), msg = "Check sgolayfilt rejects an even-row filter matrix p")
+}


### PR DESCRIPTION
dim(p) > 1 evaluates to a length-2 vector for any matrix, which errors
inside && on R >= 4.3 ("length = 2" in coercion to logical(1)). This
was never caught because inherits(p, "sgolayFilter") short-circuits
the check for every classed object produced by sgolay(), but a plain
matrix (e.g. after unclass()) hit it directly.

Replace the check with is.matrix(p), and validate that the matrix has
an odd number of rows, since the center-row assumption used to split
the filter into leading/center/trailing coefficients only holds for
odd-length filters.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AD8Yo59d9F3vkeEEqKC6wc