### PR TITLE
Fix crash with plain filter matrices and add short-input validation

### DIFF
--- a/R/sgolayfilt.R
+++ b/R/sgolayfilt.R
@@ -80,6 +80,9 @@ sgolayfilt <- function(x, p = 3, n = p + 3 - p %% 2, m = 0, ts = 1, rowwise = FA
   }
 
   n <- nrow(filt)
+  if (len < n) {
+    stop("sgolayfilt: x must have at least ", n, " observations along the filtered dimension, got ", len)
+  }
   k <- floor(n/2)
   out <- matrix(0, nrow = nrow(x), ncol = ncol(x))
 

--- a/inst/tests/runit.sgolayfilt.R
+++ b/inst/tests/runit.sgolayfilt.R
@@ -50,3 +50,24 @@ test04_sgolayfilt_even_rows_p_errors <- function() {
   x <- runif(50)
   checkException(sgolayfilt(x, even_filt), msg = "Check sgolayfilt rejects an even-row filter matrix p")
 }
+
+test05_sgolayfilt_short_x_errors <- function() {
+  # x shorter than the filter length must be rejected with a clear error
+  # instead of an obscure out-of-bounds indexing failure
+  filt <- sgolay::sgolay(p = 2, n = 5)
+  checkException(sgolayfilt(runif(3), filt), msg = "Check sgolayfilt rejects a vector shorter than the filter")
+  x <- matrix(runif(2 * 3), nrow = 2, ncol = 3)
+  checkException(sgolayfilt(x, filt, rowwise = TRUE), msg = "Check sgolayfilt rejects a rowwise matrix shorter than the filter")
+}
+
+test06_sgolayfilt_x_length_equals_filter_length <- function() {
+  # x exactly as long as the filter is the smallest valid input and must
+  # still work (boundary just above the rejected case in test05)
+  filt <- sgolay::sgolay(p = 2, n = 5)
+  x <- runif(5)
+  yref <- signal::sgolayfilt(x, filt)
+  y_filter <- sgolayfilt(x, filt, engine = "filter")
+  y_fft <- sgolayfilt(x, filt, engine = "fft")
+  checkEquals(yref, y_filter, msg = "Check sgolayfilt when length(x) == n (filter engine)")
+  checkEquals(yref, y_fft, msg = "Check sgolayfilt when length(x) == n (fft engine)")
+}


### PR DESCRIPTION
## Summary

Two correctness fixes found during a critical review of `sgolayfilt()`:

- `dim(p) > 1` evaluates to a length-2 vector for any matrix, which errors inside `&&` on R >= 4.3 (`'length = 2' in coercion to 'logical(1)'`). This was invisible in tests because `inherits(p, "sgolayFilter")` short-circuits the check for every object returned directly by `sgolay()`, but a plain matrix (e.g. after `unclass()`) hits it directly. Replaced with `is.matrix(p)`, and added validation that the matrix has an odd number of rows (required for the leading/center/trailing coefficient split to be well-defined).
- `sgolayfilt()` indexed `x[1:n, ]` / `x[(len-n+1):len, ]` for edge coefficients without checking that `x` had at least `n` observations. A shorter `x` failed with an opaque "subscript out of bounds" error. Added an explicit `len < n` check with a clear error message.

## Test plan
- [x] Reproduced both bugs on a clean R 4.3.3 install before fixing
- [x] Added regression tests: plain unclassed matrix as `p`, even-row matrix rejected, `x` shorter than filter rejected, boundary `length(x) == n` still works
- [x] Full RUnit suite passes (7/7)
- [x] `R CMD check` passes clean (no new warnings/notes)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AD8Yo59d9F3vkeEEqKC6wc)_