### PR TITLE
Add regression test for the auto engine's filter-length threshold

### DIFF
--- a/inst/tests/runit.sgolayfilt.R
+++ b/inst/tests/runit.sgolayfilt.R
@@ -71,3 +71,18 @@ test06_sgolayfilt_x_length_equals_filter_length <- function() {
   checkEquals(yref, y_filter, msg = "Check sgolayfilt when length(x) == n (filter engine)")
   checkEquals(yref, y_fft, msg = "Check sgolayfilt when length(x) == n (fft engine)")
 }
+
+test07_choose_engine_auto_threshold <- function() {
+  # filter_length > 29 was empirically chosen as the crossover where the fft
+  # engine becomes faster than the direct filter engine. Pin the exact
+  # boundary so it can't drift silently in a future refactor.
+  x <- runif(1000)
+  checkEquals(
+    "filter", sgolay:::choose_engine(x, filter_length = 29, orig_engine = "auto"),
+    msg = "auto engine must use the direct filter engine at filter_length == 29"
+  )
+  checkEquals(
+    "fft", sgolay:::choose_engine(x, filter_length = 30, orig_engine = "auto"),
+    msg = "auto engine must switch to the fft engine at filter_length == 30"
+  )
+}


### PR DESCRIPTION
## Summary

- `choose_engine()`'s `"auto"` mode switches from `"filter"` to `"fft"` once `filter_length > 29`, a threshold tuned by benchmarking where the FFT-based convolution starts outperforming the direct convolution. This crossover had no test, so a refactor could silently shift it without anything noticing.
- Added a test that calls `choose_engine()` directly at the boundary (`filter_length = 29` -> `"filter"`, `filter_length = 30` -> `"fft"`), since near the boundary both engines produce numerically identical output — asserting on `sgolayfilt()`'s result wouldn't actually prove which engine ran.

## Test plan
- [x] Full RUnit suite passes (8/8)
- [x] `R CMD check` passes clean (no new warnings/notes)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AD8Yo59d9F3vkeEEqKC6wc)_